### PR TITLE
Fix: ffmpeg OS 호환되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/ssginc/showpingrefactoring/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
                         .ignoringRequestMatchers(
                                 "/api/auth/login", "/api/auth/logout", "/api/csrf",
                                 "/api/live/register", "/api/live/live-info", "/api/live/start", "/api/live/stop",
-                                "/api/chat/**", "/api/chatRoom/**", "/ws-stomp-chat/**", "/chat/message"
+                                "/api/chat/**", "/api/chatRoom/**", "/ws-stomp-chat/**", "/chat/message", "/api/vod/upload",
+                                "/api/batch/**"
                         ))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 인가 규칙

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/HlsServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/HlsServiceImpl.java
@@ -4,6 +4,7 @@ import com.ssginc.showpingrefactoring.common.exception.CustomException;
 import com.ssginc.showpingrefactoring.common.exception.ErrorCode;
 import com.ssginc.showpingrefactoring.infrastructure.NCP.storage.StorageLoader;
 import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
+import com.ssginc.showpingrefactoring.infrastructure.ffmpeg.HlsMaker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,6 +34,8 @@ public class HlsServiceImpl implements HlsService {
     private final ResourceLoader resourceLoader;
 
     private final StorageLoader storageLoader;
+
+    private final HlsMaker hlsMaker;
 
     /**
      * 영상 제목으로 HLS 생성하여 받아오는 메서드
@@ -88,10 +91,11 @@ public class HlsServiceImpl implements HlsService {
         File outputFile = new File(dirStr, title + ".m3u8");
         File outputDir = new File(dirStr);
 
+        String ffmpeg = HlsMaker.resolveFFmpegPath();
 
         // FFmpeg를 사용하여 HLS로 변환
         ProcessBuilder processBuilder = new ProcessBuilder(
-                "ffmpeg", "-i", inputFile.getAbsolutePath(),
+                ffmpeg, "-i", inputFile.getAbsolutePath(),
                 "-codec:", "copy", "-start_number", "0",
                 "-hls_time", "10", "-hls_list_size", "0",
                 "-f", "hls", outputFile.getAbsolutePath()

--- a/src/main/java/com/ssginc/showpingrefactoring/infrastructure/ffmpeg/HlsMaker.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/infrastructure/ffmpeg/HlsMaker.java
@@ -1,0 +1,50 @@
+package com.ssginc.showpingrefactoring.infrastructure.ffmpeg;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class HlsMaker {
+    public static String resolveFFmpegPath() {
+
+        // 1) 존재하면 그대로 사용
+        if (isOnPath("ffmpeg")) return "ffmpeg";
+
+        // 2) OS별 기본 경로 후보(예시). 환경마다 바꿔 쓰세요.
+        String os = System.getProperty("os.name").toLowerCase();
+        List<String> candidates = getStrings(os);
+
+        return candidates.stream()
+                .filter(p -> Files.isRegularFile(Path.of(p)))
+                .findFirst()
+                .orElse("ffmpeg"); // 마지막 fallback
+    }
+
+    private static List<String> getStrings(String os) {
+        List<String> candidates = new ArrayList<>();
+
+        if (os.contains("win")) {
+            candidates.add("C:\\ffmpeg\\bin\\ffmpeg.exe");
+        } else if (os.contains("mac")) {
+            candidates.add("/opt/homebrew/bin/ffmpeg");   // Apple Silicon(Homebrew)
+            candidates.add("/usr/local/bin/ffmpeg");      // Intel(Homebrew)
+            candidates.add("/opt/local/bin/ffmpeg");      // MacPorts
+        } else { // linux 등
+            candidates.add("/usr/bin/ffmpeg");
+            candidates.add("/usr/local/bin/ffmpeg");
+        }
+        return candidates;
+    }
+
+    private static boolean isOnPath(String cmd) {
+        try {
+            Process p = new ProcessBuilder(cmd, "-version")
+                    .redirectErrorStream(true).start();
+            return p.waitFor() == 0;
+        } catch (Exception ignore) { return false; }
+    }
+}


### PR DESCRIPTION
## 작업 소개
 - ffmpeg 활용 HLS 생성시 ProcessBuilder를 활용하여 작업 수행을 진행
   → 이 과정에서 운영체제별로 ffmpeg을 찾을 수 없어 진행되지 않는 문제 발생
 - OS별로 ffmpeg 실행파일을 찾는 로직을 추가하여 구현
***
## 참고사항
 - ffmpeg이 필수적으로 저장되어야 할 경로
   - windows: ```C:\\ffmpeg\\bin\\ffmpeg.exe```
   - mac(Apple Silicon): ```/opt/homebrew/bin/ffmpeg```
   - mac(Intel): ```/usr/local/bin/ffmpeg```